### PR TITLE
Fix: Replace REOWN projectId empty string default with explicit validation #22

### DIFF
--- a/frontend/src/config/wagmi.ts
+++ b/frontend/src/config/wagmi.ts
@@ -5,8 +5,33 @@ import { QueryClient } from '@tanstack/react-query'
 import { cookieToInitialState } from 'wagmi'
 import type { AppKitNetwork } from '@reown/appkit/networks'
 
-// Get projectId from environment variables
-export const projectId = import.meta.env.VITE_REOWN_PROJECT_ID || ''
+/**
+ * Get and validate REOWN Project ID from environment variables
+ * Throws an error if projectId is not configured to prevent silent failures
+ */
+function getProjectId(): string {
+  const projectId = import.meta.env.VITE_REOWN_PROJECT_ID
+
+  if (!projectId) {
+    throw new Error(
+      'VITE_REOWN_PROJECT_ID is not configured. ' +
+      'This is required for REOWN AppKit wallet connections. ' +
+      'Get your Project ID from https://cloud.reown.com/ and add it to your .env file.'
+    )
+  }
+
+  if (typeof projectId !== 'string' || projectId.trim() === '') {
+    throw new Error(
+      'VITE_REOWN_PROJECT_ID is invalid. It must be a non-empty string. ' +
+      'Check your .env file configuration.'
+    )
+  }
+
+  return projectId
+}
+
+// Get projectId from environment variables with validation
+export const projectId = getProjectId()
 
 // Set up metadata for the dApp
 export const metadata = {


### PR DESCRIPTION
Closes #22

  ## Summary
  Replaced silent empty string default for REOWN projectId with explicit validation that throws clear errors when misconfigured.

  ## Problem
  Previously, if `VITE_REOWN_PROJECT_ID` was not set, the code silently defaulted to an empty string:
  ```typescript
  export const projectId = import.meta.env.VITE_REOWN_PROJECT_ID || ''

  This masked configuration problems and led to:
  - Silent failures at runtime
  - Difficult debugging (wallet connections mysteriously failing)
  - No clear error messages
  - Developers unaware of misconfiguration

  Solution

  Created getProjectId() validation function that:
  - ✅ Throws explicit error if projectId is missing
  - ✅ Validates projectId is a non-empty string
  - ✅ Provides clear, actionable error messages
  - ✅ Includes link to get Project ID from REOWN Cloud
  - ✅ Guides developers to check .env configuration

  Error Messages

  Missing projectId:
  VITE_REOWN_PROJECT_ID is not configured. 
  This is required for REOWN AppKit wallet connections. 
  Get your Project ID from https://cloud.reown.com/ and add it to your .env file.

  Invalid projectId:
  VITE_REOWN_PROJECT_ID is invalid. It must be a non-empty string. 
  Check your .env file configuration.

  Testing

  - ✅ TypeScript compilation passes
  - ✅ Validation properly throws errors for missing/invalid projectId
  - ✅ Works correctly with valid projectId configuration

  Impact

  - Fail fast - Configuration errors caught at startup, not runtime
  - Better DX - Clear guidance for developers
  - Easier debugging - No more mysterious wallet connection failures

All done! The REOWN projectId validation is now explicit and helpful! 🎉