### PR TITLE
fix: Issue #3 - Fix hardcoded explorer URL in WalletInfo component

### DIFF
--- a/frontend/src/components/WalletInfo.tsx
+++ b/frontend/src/components/WalletInfo.tsx
@@ -3,6 +3,16 @@ import { useAccount, useBalance, useDisconnect } from 'wagmi'
 import { formatEther } from 'viem'
 import { CheckIcon, DocumentDuplicateIcon } from '@heroicons/react/24/outline'
 
+// Network explorer URLs mapping
+const NETWORK_EXPLORERS = {
+  84532: 'https://sepolia.basescan.org', // Base Sepolia
+  8453: 'https://basescan.org',          // Base Mainnet
+  1: 'https://etherscan.io',            // Ethereum Mainnet
+  11155111: 'https://sepolia.etherscan.io', // Ethereum Sepolia
+  137: 'https://polygonscan.com',        // Polygon Mainnet
+  80001: 'https://mumbai.polygonscan.com', // Polygon Mumbai
+} as const
+
 export function WalletInfo() {
   const { address, isConnected, chain } = useAccount()
   const { disconnect } = useDisconnect()
@@ -92,7 +102,14 @@ export function WalletInfo() {
       <div className="wallet-actions">
         <button
           className="btn-secondary"
-          onClick={() => window.open(`https://sepolia.basescan.org/address/${address}`, '_blank')}
+          onClick={() => {
+            const explorerUrl = chain?.id ? NETWORK_EXPLORERS[chain.id as keyof typeof NETWORK_EXPLORERS] : null
+            if (explorerUrl) {
+              window.open(`${explorerUrl}/address/${address}`, '_blank')
+            } else {
+              alert('Explorer not available for this network')
+            }
+          }}
         >
           View on Explorer
         </button>


### PR DESCRIPTION
- Added dynamic network explorer URLs mapping
- Replaced hardcoded Base Sepolia URL with dynamic lookup based on chain ID
- Supports Base Sepolia, Base Mainnet, Ethereum Mainnet, Ethereum Sepolia, Polygon networks
- Added fallback alert for unsupported networks