### PR TITLE
fix: add missing useEffect import in MobileNavigation.tsx

### DIFF
--- a/frontend/src/components/MobileNavigation.tsx
+++ b/frontend/src/components/MobileNavigation.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 interface MobileNavigationProps {
   currentPage: string


### PR DESCRIPTION
- Import useEffect from React in MobileNavigation.tsx
- Fixes the useMobileNav hook which was using useEffect without importing it
- Resolves build error: 'useEffect' is not defined

closes: #75