### PR TITLE
fix: Optimize WalletConnectPage performance with manual refresh and m…

### DIFF
--- a/frontend/src/components/WalletConnectPage.tsx
+++ b/frontend/src/components/WalletConnectPage.tsx
@@ -4,18 +4,15 @@ import { WalletButton } from './WalletButton'
 import { TransactionToast } from './TransactionToast'
 import { useAccount } from 'wagmi'
 import { getWalletHistory, clearWalletHistory } from '../utils/walletStorage'
-import { useState, useEffect } from 'react'
+import { useState, useCallback } from 'react'
 
 export function WalletConnectPage() {
   const { isConnected } = useAccount()
   const [history, setHistory] = useState(getWalletHistory())
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setHistory(getWalletHistory())
-    }, 1000)
-
-    return () => clearInterval(interval)
+  // Memoized refresh function to prevent unnecessary re-renders
+  const refreshHistory = useCallback(() => {
+    setHistory(getWalletHistory())
   }, [])
 
   const handleClearHistory = () => {
@@ -23,6 +20,10 @@ export function WalletConnectPage() {
       clearWalletHistory()
       setHistory([])
     }
+  }
+
+  const handleRefreshHistory = () => {
+    refreshHistory()
   }
 
   return (
@@ -69,14 +70,23 @@ export function WalletConnectPage() {
         <div className="wallet-section">
           <div className="section-header">
             <h2>Connection History</h2>
-            {history.length > 0 && (
+            <div className="history-actions">
               <button
-                className="btn-clear"
-                onClick={handleClearHistory}
+                className="btn-refresh"
+                onClick={handleRefreshHistory}
+                title="Refresh history"
               >
-                Clear
+                🔄
               </button>
-            )}
+              {history.length > 0 && (
+                <button
+                  className="btn-clear"
+                  onClick={handleClearHistory}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
           </div>
 
           {history.length === 0 ? (

--- a/frontend/src/styles/walletConnect.css
+++ b/frontend/src/styles/walletConnect.css
@@ -505,6 +505,38 @@
   margin-bottom: 1.5rem;
 }
 
+.history-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.btn-refresh {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  padding: 0.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.btn-refresh:hover {
+  background: rgba(124, 58, 237, 0.1);
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.btn-refresh:active {
+  transform: scale(0.95);
+}
+
 .btn-clear {
   background: transparent;
   border: 1px solid var(--error);


### PR DESCRIPTION
…emoization

- Removed automatic polling with setInterval that was causing unnecessary re-renders every second
- Replaced useEffect polling with manual refresh button for user-controlled updates
- Added memoized refreshHistory function using useCallback to prevent unnecessary re-renders
- Added refresh button with proper styling for manual history updates
- Improved performance by eliminating 1-second interval that was constantly calling getWalletHistory()
- Users can now manually refresh history when needed instead of constant background polling

fixes: #91 