### PR TITLE
Fix issue 27: Add missing trackProps parameter to interface

### DIFF
--- a/frontend/src/hooks/usePerformanceMonitor.ts
+++ b/frontend/src/hooks/usePerformanceMonitor.ts
@@ -7,6 +7,7 @@ interface PerformanceMonitorOptions {
   trackMount?: boolean;
   trackUnmount?: boolean;
   track?: boolean;
+  trackProps?: boolean;
   trackState?: boolean;
   thresholds?: {
     render?: number;


### PR DESCRIPTION
- Add trackProps?: boolean to PerformanceMonitorOptions interface
- This parameter was being used in the code but missing from the interface definition
- Enables proper TypeScript type checking for prop change tracking

closes: #99 