### PR TITLE
Fix issue 28: Resolve performance monitoring logic error

### DIFF
--- a/frontend/src/hooks/usePerformanceMonitor.ts
+++ b/frontend/src/hooks/usePerformanceMonitor.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
-import { markPerformanceStart, getPerformanceMetrics } from '../utils/performance';
+import { markPerformanceStart, getPerformanceMetrics, recordAdvancedMetric } from '../utils/performance';
 
 interface PerformanceMonitorOptions {
   componentName: string;
@@ -67,9 +67,13 @@ export function usePerformanceMonitor(options: PerformanceMonitorOptions) {
    * Records a performance measurement with automatic categorization
    */
   const recordMeasurement = useCallback((operation: string, duration: number, category: string = 'interaction') => {
-    // Use the existing markPerformanceStart function
-    const endMeasurement = markPerformanceStart(`${componentName}_${operation}`);
-    endMeasurement();
+    // Record the measurement with the provided duration
+    recordAdvancedMetric({
+      name: `${componentName}_${operation}`,
+      value: duration,
+      timestamp: Date.now(),
+      category: category as any
+    });
   }, [componentName]);
 
   /**

--- a/frontend/src/utils/performance.ts
+++ b/frontend/src/utils/performance.ts
@@ -82,7 +82,7 @@ export function markPerformanceStart(name: string, category: PerformanceMetric['
 /**
  * Records a performance metric with enhanced metadata
  */
-function recordAdvancedMetric(metric: PerformanceMetric) {
+export function recordAdvancedMetric(metric: PerformanceMetric) {
   performanceMetrics.push(metric)
   
   // Keep only the most recent metrics to prevent memory issues


### PR DESCRIPTION
- Export recordAdvancedMetric function from performance utils
- Fix recordMeasurement function to properly use provided duration parameter
- Previously ignored the duration parameter and created incorrect timing measurements
- Now correctly records performance measurements with actual measured durations

closes: #101 